### PR TITLE
Feat/create channel

### DIFF
--- a/README-DOCKERHUB.md
+++ b/README-DOCKERHUB.md
@@ -18,6 +18,7 @@ The commands are executed by using slash commands as follows:
 - `/role update <role> <role field> <role field value>`
 - `/role create-channel <role> <channel name> <channel type>`
 - `/role link-channel <role> <channel>`
+- `/role remove-channel <role> <channel>`
 - `/role help <command name>`
 
 If unsuccessful, the bot will reply with an error message and usage.

--- a/README-DOCKERHUB.md
+++ b/README-DOCKERHUB.md
@@ -11,15 +11,17 @@ React Roles is a simple discord bot for allowing self-managing user roles in dis
 
 For the most up-to-date information, check the [Github Repo here](https://github.com/Zaptross/reactroles#react-roles)!
 
-The commands are called by sending messages structured like the following:
+The commands are executed by using slash commands as follows:
 
 - `/role add <role name> <emoji> [colour]`
-- `/role remove <role name>`
-- `/role update <role name> <role field> <role field value>`
+- `/role remove <role>`
+- `/role update <role> <role field> <role field value>`
+- `/role create-channel <role> <channel name> <channel type>`
+- `/role link-channel <role> <channel>`
 - `/role help <command name>`
 
 If unsuccessful, the bot will reply with an error message and usage.
 
-## Setup
+## Configuration & Setup
 
-For setup instructions, please see the [Github Repo here](https://github.com/Zaptross/reactroles#react-roles)
+For configuration and setup instructions, please see the [Github Repo here](https://github.com/Zaptross/reactroles#react-roles)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ If a user has the roles (as configured below) that gives the permission to use r
 - <> : a required parameter
 - [] : an optional parameter
 
+### Configuration
+
+The bot is configured per server via the `configure` command.
+
+To configure the bot, you will need:
+
+- A channel for the bot to post the role selector messages in (e.g. `#roles`)
+- One or more roles to use as permission roles for managing roles (e.g. `@role-add, @role-update, @role-remove`)
+  - These can be the same role if you want to give all permissions to one role
+- Is creating and removing channels enabled? (e.g. `true, false`)
+- What category should the bot create new role channels in? (e.g. `📁 role-channels`)
+  - This is only used if creating and removing channels is enabled
+- One or more roles to use as permission roles for managing role channels (e.g. `@role-channel-create, @role-channel-remove`)
+  - These can be the same as the role management role
+
+#### Example
+
+- `/role configure <role channel> <add role> <remove role> <update role> <create channel> <create channel role> <remove channel role> <channel category> <cascadeDelete>`
+- `/role configure #roles @role-add @role-remove @role-update true  @role-channel-create @role-channel-remove role-channels true`
+
 ### Add Command
 
 Adds a new role to the discord, configured as specified.

--- a/README.md
+++ b/README.md
@@ -51,26 +51,50 @@ Usage examples:
 
 ### Remove Command
 
-Removes a role and it's reacions from the discord.
+Removes a role, its reactions, and its channels if they exist.
 
-- `/role remove <role name>`
+- `/role remove <role>`
 
 Usage example:
 
-- `/role remove valorant`
+- `/role remove @valorant`
 
 ### Update Command
 
 Modifies any one part of a role.
 Where role fields are `name`, `emoji` and `color`, and role field values are valid values of those fields as per the `add` role command.
 
-- `/role update <role name> <role field> <role field value>`
+- `/role update <role> <role field> <role field value>`
 
 Usage examples:
 
-- `/role update valorant name coolgungame`
-- `/role update valorant emoji 😎`
-- `/role update valorant color #CADEAA`
+- `/role update @valorant name coolgungame`
+- `/role update @valorant emoji 😎`
+- `/role update @valorant color #CADEAA`
+
+### Create Channel Command
+
+Creates a new channel with the specified name, and adds the specified role to the channel.
+Roles may have zero or one text channel, and zero or one voice channel associated with them.
+
+- `/role create-channel <role> <channel name> <channel type>`
+
+Usage examples:
+
+- `/role create-channel @valorant valorant-chat text`
+- `/role create-channel @valorant valorant-voice voice`
+
+### Link Channel Command
+
+Links an existing channel to a role.
+Roles may have zero or one text channel, and zero or one voice channel associated with them.
+
+- `/role link-channel <role> <channel>`
+
+Usage examples:
+
+- `/role link-channel @valorant #valorant-chat`
+- `/role link-channel @valorant 🔊valorant-voice`
 
 ### Help Command
 
@@ -81,10 +105,6 @@ Replies to the user the help text accompanying the command.
 Usage example:
 
 - `/role help add`
-
-As of v2.6.0 (3ee3b59)
-
-If unsuccessful, the bot will reply with an error message and usage.
 
 # Setup
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ Usage examples:
 - `/role link-channel @valorant #valorant-chat`
 - `/role link-channel @valorant 🔊valorant-voice`
 
+### Remove Channel Command
+
+Removes a channel from a role, and deletes the channel.
+
+- `/role remove-channel <role> <channel>`
+
+Usage examples:
+
+- `/role remove-channel @valorant #valorant-chat`
+
 ### Help Command
 
 Replies to the user the help text accompanying the command.

--- a/internal/dgclient/actions.go
+++ b/internal/dgclient/actions.go
@@ -5,10 +5,11 @@ import (
 )
 
 type ActionNames struct {
-	Add    string
-	Remove string
-	Update string
-	Help   string
+	Add           string
+	Remove        string
+	Update        string
+	CreateChannel string
+	Help          string
 }
 
 const (
@@ -16,10 +17,11 @@ const (
 )
 
 var Actions = ActionNames{
-	Add:    "add",
-	Update: "update",
-	Remove: "remove",
-	Help:   "help",
+	Add:           "add",
+	Update:        "update",
+	Remove:        "remove",
+	CreateChannel: "create-channel",
+	Help:          "help",
 }
 
 func (a ActionNames) All() []string {

--- a/internal/dgclient/actions.go
+++ b/internal/dgclient/actions.go
@@ -9,6 +9,7 @@ type ActionNames struct {
 	Remove        string
 	Update        string
 	CreateChannel string
+	LinkChannel   string
 	Help          string
 }
 
@@ -21,6 +22,7 @@ var Actions = ActionNames{
 	Update:        "update",
 	Remove:        "remove",
 	CreateChannel: "create-channel",
+	LinkChannel:   "link-channel",
 	Help:          "help",
 }
 

--- a/internal/dgclient/actions.go
+++ b/internal/dgclient/actions.go
@@ -10,6 +10,7 @@ type ActionNames struct {
 	Update        string
 	CreateChannel string
 	LinkChannel   string
+	RemoveChannel string
 	Help          string
 }
 
@@ -23,6 +24,7 @@ var Actions = ActionNames{
 	Remove:        "remove",
 	CreateChannel: "create-channel",
 	LinkChannel:   "link-channel",
+	RemoveChannel: "remove-channel",
 	Help:          "help",
 }
 

--- a/internal/dgclient/createChannel.go
+++ b/internal/dgclient/createChannel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/samber/lo"
 	"github.com/zaptross/reactroles/internal/pgdb"
 )
 
@@ -104,6 +105,9 @@ func handleCreateChannelSlashCommand(client *DiscordGoClient, s *discordgo.Sessi
 }
 
 func validateCreateChannelCommand(client *DiscordGoClient, guildId string, role *discordgo.Role, category *discordgo.Channel, name string, channelType string, server *pgdb.ServerConfiguration, i *discordgo.InteractionCreate) error {
+	if !lo.Contains(i.Member.Roles, server.ChannelCreateRoleID) {
+		return fmt.Errorf("you do not have permission to create channels for roles")
+	}
 
 	if role == nil {
 		return fmt.Errorf("no such role exists")

--- a/internal/dgclient/createChannel.go
+++ b/internal/dgclient/createChannel.go
@@ -1,0 +1,141 @@
+package dgclient
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/zaptross/reactroles/internal/pgdb"
+)
+
+func createChannelSlashCommand() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Name:        Actions.CreateChannel,
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Description: "Create a new text or voice channel for a given role.",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        "role",
+				Description: "The role to create a channel for.",
+				Required:    true,
+			},
+			{
+				Type:         discordgo.ApplicationCommandOptionChannel,
+				Name:         "category",
+				Description:  "The category to create the channel in.",
+				Required:     true,
+				ChannelTypes: []discordgo.ChannelType{discordgo.ChannelTypeGuildCategory},
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "name",
+				Description: "The name of the channel to create.",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "type",
+				Description: "The type of channel to create.",
+				Required:    true,
+				Choices: []*discordgo.ApplicationCommandOptionChoice{
+					{Name: "text", Value: "text"},
+					{Name: "voice", Value: "voice"},
+				},
+			},
+		},
+	}
+}
+
+func handleCreateChannelSlashCommand(client *DiscordGoClient, s *discordgo.Session, i *discordgo.InteractionCreate, server *pgdb.ServerConfiguration) {
+	sc := i.ApplicationCommandData().Options[0]
+	role := sc.Options[0].RoleValue(s, i.GuildID)
+	category := sc.Options[1].ChannelValue(s)
+	name := sc.Options[2].StringValue()
+	channelType := sc.Options[3].StringValue()
+
+	err := validateCreateChannelCommand(client, i.GuildID, role, category, name, channelType, server, i)
+	if err != nil {
+		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: fmt.Sprintf("Error: %s", err.Error()),
+		})
+		return
+	}
+
+	createdChannel, err := client.Session.GuildChannelCreateComplex(i.GuildID, discordgo.GuildChannelCreateData{
+		Name:     name,
+		Type:     channelTypeFromString(channelType),
+		ParentID: category.ID,
+		PermissionOverwrites: []*discordgo.PermissionOverwrite{
+			{
+				ID:    role.ID,
+				Allow: discordgo.PermissionViewChannel,
+			},
+			{
+				ID:   i.GuildID,
+				Deny: discordgo.PermissionViewChannel,
+			},
+		},
+	})
+
+	if err != nil {
+		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: fmt.Sprintf("Error creating channel: %s", err.Error()),
+		})
+		return
+	}
+
+	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: fmt.Sprintf("Channel %s created for role %s in category %s", createdChannel.Mention(), role.Mention(), category.Mention()),
+	})
+
+	if channelType == "text" {
+		client.db.RoleUpdateTextChannel(role.ID, createdChannel.ID, i.GuildID)
+	} else {
+		client.db.RoleUpdateVoiceChannel(role.ID, createdChannel.ID, i.GuildID)
+	}
+}
+
+func validateCreateChannelCommand(client *DiscordGoClient, guildId string, role *discordgo.Role, category *discordgo.Channel, name string, channelType string, server *pgdb.ServerConfiguration, i *discordgo.InteractionCreate) error {
+
+	if role == nil {
+		return fmt.Errorf("no such role exists")
+	}
+
+	if category == nil {
+		return fmt.Errorf("no such category exists")
+	}
+
+	allChannels, err := client.Session.GuildChannels(guildId)
+
+	if err != nil {
+		return err
+	}
+
+	for _, channel := range allChannels {
+		if channel.Name == name {
+			return fmt.Errorf("a channel named %s already exists", name)
+		}
+	}
+
+	if channelType != "text" && channelType != "voice" {
+		return fmt.Errorf("invalid channel type: %s", channelType)
+	}
+
+	if client.db.RoleGetById(role.ID, guildId).TextChannelID != "" && channelType == "text" {
+		return fmt.Errorf("%s already has a text channel", role.Name)
+	}
+
+	if client.db.RoleGetById(role.ID, guildId).VoiceChannelID != "" && channelType == "voice" {
+		return fmt.Errorf("%s already has a voice channel", role.Name)
+	}
+
+	return nil
+}
+
+func channelTypeFromString(channelType string) discordgo.ChannelType {
+	if channelType == "text" {
+		return discordgo.ChannelTypeGuildText
+	}
+
+	return discordgo.ChannelTypeGuildVoice
+}

--- a/internal/dgclient/linkChannel.go
+++ b/internal/dgclient/linkChannel.go
@@ -1,0 +1,131 @@
+package dgclient
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/samber/lo"
+	"github.com/zaptross/reactroles/internal/pgdb"
+)
+
+func linkChannelSlashCommand() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Name:        Actions.LinkChannel,
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Description: "Link a channel to a role.",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        "role",
+				Description: "The role to link.",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionChannel,
+				Name:        "channel",
+				Description: "The channel to link.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func handleLinkChannelSlashCommand(client *DiscordGoClient, s *discordgo.Session, i *discordgo.InteractionCreate, server *pgdb.ServerConfiguration) {
+	sc := i.ApplicationCommandData().Options[0]
+	role := sc.Options[0].RoleValue(s, i.GuildID)
+	channel := sc.Options[1].ChannelValue(s)
+
+	channelType := ""
+	if channel.Type == discordgo.ChannelTypeGuildText {
+		channelType = "text"
+	} else if channel.Type == discordgo.ChannelTypeGuildVoice {
+		channelType = "voice"
+	}
+
+	err := validateLinkChannelCommand(client, i.GuildID, channel, role, server, i, channelType)
+	if err != nil {
+		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: fmt.Sprintf("Error: %s", err.Error()),
+		})
+		return
+	}
+
+	requiredOverrides := []*discordgo.PermissionOverwrite{}
+
+	if !channelHasRolePermissionConfiguration(channel, role.ID, discordgo.PermissionViewChannel) {
+		requiredOverrides = append(requiredOverrides, &discordgo.PermissionOverwrite{
+			ID:    role.ID,
+			Type:  discordgo.PermissionOverwriteTypeRole,
+			Allow: discordgo.PermissionViewChannel,
+		})
+	}
+
+	if !channelHasRolePermissionConfiguration(channel, role.ID, discordgo.PermissionViewChannel) {
+		requiredOverrides = append(requiredOverrides, &discordgo.PermissionOverwrite{
+			ID:    s.State.User.ID,
+			Type:  discordgo.PermissionOverwriteTypeMember,
+			Allow: discordgo.PermissionViewChannel,
+		})
+	}
+
+	if !channelHasRolePermissionConfiguration(channel, i.GuildID, discordgo.PermissionViewChannel) {
+		requiredOverrides = append(requiredOverrides, &discordgo.PermissionOverwrite{
+			ID:   i.GuildID,
+			Type: discordgo.PermissionOverwriteTypeRole,
+			Deny: discordgo.PermissionViewChannel,
+		})
+	}
+
+	if len(requiredOverrides) > 0 {
+		_, err = s.ChannelEditComplex(channel.ID, &discordgo.ChannelEdit{
+			PermissionOverwrites: append(channel.PermissionOverwrites, requiredOverrides...),
+		})
+
+		if err != nil {
+			s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+				Content: "Error: failed to update permissions for channel",
+			})
+			println(err.Error())
+			return
+		}
+	}
+
+	client.db.RoleLinkChannel(channel.ID, role.ID, i.GuildID, channelType)
+
+	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: fmt.Sprintf("Channel %s linked to role %s.", channel.Mention(), role.Mention()),
+	})
+}
+
+func validateLinkChannelCommand(client *DiscordGoClient, guildId string, channel *discordgo.Channel, role *discordgo.Role, server *pgdb.ServerConfiguration, i *discordgo.InteractionCreate, channelType string) error {
+	if !(lo.Contains(i.Member.Roles, server.ChannelCreateRoleID) && lo.Contains(i.Member.Roles, server.ChannelRemoveRoleID)) {
+		return errors.New("you must have the channel create and remove roles to link a channel")
+	}
+
+	dbRole := client.db.RoleGetById(role.ID, guildId)
+
+	if channelType != "text" && channelType != "voice" {
+		return errors.New("channel type must be text or voice")
+	}
+
+	if channelType == "voice" && dbRole.VoiceChannelID != "" {
+		return errors.New("role is already linked to a voice channel")
+	}
+
+	if channelType == "text" && dbRole.TextChannelID != "" {
+		return errors.New("role is already linked to a text channel")
+	}
+
+	if channel.ParentID != server.ChannelCategoryID {
+		return errors.New("channel must be in the configured category")
+	}
+
+	return nil
+}
+
+func channelHasRolePermissionConfiguration(channel *discordgo.Channel, roleId string, permission int64) bool {
+	return lo.ContainsBy(channel.PermissionOverwrites, func(po *discordgo.PermissionOverwrite) bool {
+		return po.ID == roleId && po.Allow&permission == permission
+	})
+}

--- a/internal/dgclient/removeChannel.go
+++ b/internal/dgclient/removeChannel.go
@@ -1,0 +1,90 @@
+package dgclient
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/samber/lo"
+	"github.com/zaptross/reactroles/internal/pgdb"
+)
+
+func removeChannelSlashCommand() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Name:        Actions.RemoveChannel,
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Description: "Remove a channel for a given role.",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        "role",
+				Description: "The role to remove a channel for.",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionChannel,
+				Name:        "channel",
+				Description: "The channel to remove. This channel must be linked to the role.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func handleRemoveChannelSlashCommand(client *DiscordGoClient, s *discordgo.Session, i *discordgo.InteractionCreate, server *pgdb.ServerConfiguration) {
+	sc := i.ApplicationCommandData().Options[0]
+	role := sc.Options[0].RoleValue(s, i.GuildID)
+	channel := sc.Options[1].ChannelValue(s)
+
+	channelType := ""
+	if channel.Type == discordgo.ChannelTypeGuildText {
+		channelType = "text"
+	} else if channel.Type == discordgo.ChannelTypeGuildVoice {
+		channelType = "voice"
+	}
+
+	err := validateRemoveChannelCommand(client, i.GuildID, channel, role, server, i, channelType)
+	if err != nil {
+		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: err.Error(),
+		})
+		return
+	}
+
+	_, err = s.ChannelDelete(channel.ID)
+	if err != nil {
+		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: "Error: failed to delete channel",
+		})
+		println(err.Error())
+		return
+	}
+
+	client.db.RoleChannelRemove(role.ID, i.GuildID, channelType)
+
+	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: fmt.Sprintf("Channel %s removed for role %s", channel.Name, role.Name),
+	})
+}
+
+func validateRemoveChannelCommand(client *DiscordGoClient, guildID string, channel *discordgo.Channel, role *discordgo.Role, server *pgdb.ServerConfiguration, i *discordgo.InteractionCreate, channelType string) error {
+	if !lo.Contains(i.Member.Roles, server.ChannelRemoveRoleID) {
+		return fmt.Errorf("you do not have permission to remove channels")
+	}
+
+	if channelType == "" {
+		return errors.New("channel type is not valid")
+	}
+
+	if channel.GuildID != guildID {
+		return fmt.Errorf("channel %s is not in this server", channel.Name)
+	}
+
+	dbRole := client.db.RoleGetById(role.ID, guildID)
+
+	if dbRole.TextChannelID != channel.ID && dbRole.VoiceChannelID != channel.ID {
+		return fmt.Errorf("channel %s is not linked to role %s", channel.Mention(), role.Mention())
+	}
+
+	return nil
+}

--- a/internal/dgclient/removeRole.go
+++ b/internal/dgclient/removeRole.go
@@ -69,6 +69,10 @@ func handleRemoveAction(params RoleCommandParams) {
 		println(reactRemoveErr.Error())
 	}
 
+	if params.Server.ChannelCascadeDelete && (role.TextChannelID != "" || role.VoiceChannelID != "") {
+		deleteChannelsForRole(params.Client, params.GuildID(), role.TextChannelID, role.VoiceChannelID)
+	}
+
 	params.Client.db.RoleRemove(id, params.GuildID())
 	params.Reply(fmt.Sprintf("Removed role %s %s", removeRoleParams.Name, role.Emoji))
 }
@@ -103,4 +107,22 @@ func handleRemoveRoleSlashCommand(client *DiscordGoClient, s *discordgo.Session,
 	}
 
 	handleRemoveAction(params)
+}
+
+func deleteChannelsForRole(client *DiscordGoClient, guildID string, textChannel string, voiceChannel string) {
+	if textChannel != "" {
+		_, err := client.Session.ChannelDelete(textChannel)
+
+		if err != nil {
+			println(err.Error())
+		}
+	}
+
+	if voiceChannel != "" {
+		_, err := client.Session.ChannelDelete(voiceChannel)
+
+		if err != nil {
+			println(err.Error())
+		}
+	}
 }

--- a/internal/dgclient/slashCommand.go
+++ b/internal/dgclient/slashCommand.go
@@ -33,6 +33,8 @@ func (client *DiscordGoClient) GetOnInteractionHandler() func(*discordgo.Session
 			handleHelpSlashCommand(client, s, i, server)
 		case ActionConfigure:
 			handleConfigureSlashCommand(client, s, i)
+		case Actions.CreateChannel:
+			handleCreateChannelSlashCommand(client, s, i, server)
 		}
 	}
 }
@@ -47,6 +49,7 @@ func (client *DiscordGoClient) GetSlashCommand() *discordgo.ApplicationCommand {
 			updateRoleSlashCommand(),
 			helpSlashCommand(),
 			configureServerSlashCommand(),
+			createChannelSlashCommand(),
 		},
 	}
 }

--- a/internal/dgclient/slashCommand.go
+++ b/internal/dgclient/slashCommand.go
@@ -37,6 +37,8 @@ func (client *DiscordGoClient) GetOnInteractionHandler() func(*discordgo.Session
 			handleCreateChannelSlashCommand(client, s, i, server)
 		case Actions.LinkChannel:
 			handleLinkChannelSlashCommand(client, s, i, server)
+		case Actions.RemoveChannel:
+			handleRemoveChannelSlashCommand(client, s, i, server)
 		}
 	}
 }
@@ -53,6 +55,7 @@ func (client *DiscordGoClient) GetSlashCommand() *discordgo.ApplicationCommand {
 			configureServerSlashCommand(),
 			createChannelSlashCommand(),
 			linkChannelSlashCommand(),
+			removeChannelSlashCommand(),
 		},
 	}
 }

--- a/internal/dgclient/slashCommand.go
+++ b/internal/dgclient/slashCommand.go
@@ -35,6 +35,8 @@ func (client *DiscordGoClient) GetOnInteractionHandler() func(*discordgo.Session
 			handleConfigureSlashCommand(client, s, i)
 		case Actions.CreateChannel:
 			handleCreateChannelSlashCommand(client, s, i, server)
+		case Actions.LinkChannel:
+			handleLinkChannelSlashCommand(client, s, i, server)
 		}
 	}
 }
@@ -50,6 +52,7 @@ func (client *DiscordGoClient) GetSlashCommand() *discordgo.ApplicationCommand {
 			helpSlashCommand(),
 			configureServerSlashCommand(),
 			createChannelSlashCommand(),
+			linkChannelSlashCommand(),
 		},
 	}
 }

--- a/internal/pgdb/role.go
+++ b/internal/pgdb/role.go
@@ -10,6 +10,10 @@ type Role struct {
 	GuildID   string
 	Name      string
 	Emoji     string
+
+	// If these are set, these channels require this role to view
+	VoiceChannelID string
+	TextChannelID  string
 }
 
 func (db *ReactRolesDatabase) RoleGetIdByEmoji(emoji string) string {
@@ -36,6 +40,13 @@ func (db *ReactRolesDatabase) RoleAdd(id string, emoji string, name string, guil
 
 func (db *ReactRolesDatabase) RoleUpdate(id string, emoji string, name string, guildId string) {
 	db.DB.Model(&Role{}).Where("id = ? AND guild_id = ?", id, guildId).Updates(Role{Emoji: emoji, Name: name})
+}
+
+func (db *ReactRolesDatabase) RoleUpdateVoiceChannel(id string, voiceChannel string, guildId string) {
+	db.DB.Model(&Role{}).Where("id = ? AND guild_id = ?", id, guildId).Updates(Role{VoiceChannelID: voiceChannel})
+}
+func (db *ReactRolesDatabase) RoleUpdateTextChannel(id string, textChannel string, guildId string) {
+	db.DB.Model(&Role{}).Where("id = ? AND guild_id = ?", id, guildId).Updates(Role{TextChannelID: textChannel})
 }
 
 func (db *ReactRolesDatabase) RoleRemove(id string, guildId string) {

--- a/internal/pgdb/role.go
+++ b/internal/pgdb/role.go
@@ -90,3 +90,12 @@ func (db *ReactRolesDatabase) RoleLinkChannel(channelId string, roleId string, g
 		db.DB.Model(&Role{}).Where("id = ? AND guild_id = ?", roleId, guildId).Updates(Role{VoiceChannelID: channelId})
 	}
 }
+
+func (db *ReactRolesDatabase) RoleChannelRemove(roleId string, guildId string, channelType string) {
+	// For some reason, gorm doesn't like to update string fields to empty strings
+	if channelType == "text" {
+		db.DB.Exec("UPDATE roles SET text_channel_id = '' WHERE id = ? AND guild_id = ?", roleId, guildId)
+	} else {
+		db.DB.Exec("UPDATE roles SET voice_channel_id = '' WHERE id = ? AND guild_id = ?", roleId, guildId)
+	}
+}

--- a/internal/pgdb/role.go
+++ b/internal/pgdb/role.go
@@ -82,3 +82,11 @@ func (db *ReactRolesDatabase) RoleGetCount(guildId string) int {
 	db.DB.Model(&Role{}).Where("guild_id = ?", guildId).Count(&count)
 	return int(count)
 }
+
+func (db *ReactRolesDatabase) RoleLinkChannel(channelId string, roleId string, guildId string, channelType string) {
+	if channelType == "text" {
+		db.DB.Model(&Role{}).Where("id = ? AND guild_id = ?", roleId, guildId).Updates(Role{TextChannelID: channelId})
+	} else {
+		db.DB.Model(&Role{}).Where("id = ? AND guild_id = ?", roleId, guildId).Updates(Role{VoiceChannelID: channelId})
+	}
+}

--- a/internal/pgdb/server.go
+++ b/internal/pgdb/server.go
@@ -21,6 +21,8 @@ type ServerConfiguration struct {
 
 	//// Channel Creation
 	ChannelCreation      bool
+	ChannelCreateRoleID  string
+	ChannelRemoveRoleID  string
 	ChannelCategoryID    string
 	ChannelCascadeDelete bool
 }
@@ -44,6 +46,8 @@ func (db *ReactRolesDatabase) ServerConfigurationCreate(
 	updateRole string,
 	selectorChannel string,
 	channelCreation bool,
+	channelCreateRoleID string,
+	channelRemoveRoleID string,
 	channelCategoryID string,
 	channelCascadeDelete bool,
 ) *ServerConfiguration {
@@ -54,6 +58,8 @@ func (db *ReactRolesDatabase) ServerConfigurationCreate(
 		RoleUpdateRoleID:     updateRole,
 		SelectorChannelID:    selectorChannel,
 		ChannelCreation:      channelCreation,
+		ChannelCreateRoleID:  channelCreateRoleID,
+		ChannelRemoveRoleID:  channelRemoveRoleID,
 		ChannelCategoryID:    channelCategoryID,
 		ChannelCascadeDelete: channelCascadeDelete,
 	}
@@ -69,6 +75,8 @@ func (db *ReactRolesDatabase) ServerConfigurationUpdate(guildId string,
 	updateRole string,
 	selectorChannel string,
 	channelCreation bool,
+	channelCreateRoleID string,
+	channelRemoveRoleID string,
 	channelCategoryID string,
 	channelCascadeDelete bool,
 ) {
@@ -78,6 +86,8 @@ func (db *ReactRolesDatabase) ServerConfigurationUpdate(guildId string,
 		RoleUpdateRoleID:     updateRole,
 		SelectorChannelID:    selectorChannel,
 		ChannelCreation:      channelCreation,
+		ChannelCreateRoleID:  channelCreateRoleID,
+		ChannelRemoveRoleID:  channelRemoveRoleID,
 		ChannelCategoryID:    channelCategoryID,
 		ChannelCascadeDelete: channelCascadeDelete,
 	})

--- a/internal/pgdb/server.go
+++ b/internal/pgdb/server.go
@@ -8,15 +8,21 @@ type ServerConfiguration struct {
 	DeletedAt time.Time
 	GuildID   string `gorm:"primarykey"`
 
+	// Permissions
 	// These are the role IDs that the bot will use to determine if a user has
 	// permission to perform certain actions.
 	RoleAddRoleID    string
 	RoleRemoveRoleID string
 	RoleUpdateRoleID string
 
+	//// Selectors
 	// The channel ID where the bot will listen for role reactions and send role
-	// selector messages.
 	SelectorChannelID string
+
+	//// Channel Creation
+	ChannelCreation      bool
+	ChannelCategoryID    string
+	ChannelCascadeDelete bool
 }
 
 func (db *ReactRolesDatabase) GetAllServerConfigurations() []ServerConfiguration {
@@ -31,13 +37,25 @@ func (db *ReactRolesDatabase) ServerConfigurationGet(guildId string) *ServerConf
 	return &config
 }
 
-func (db *ReactRolesDatabase) ServerConfigurationCreate(guildId string, addRole string, removeRole string, updateRole string, selectorChannel string) *ServerConfiguration {
+func (db *ReactRolesDatabase) ServerConfigurationCreate(
+	guildId string,
+	addRole string,
+	removeRole string,
+	updateRole string,
+	selectorChannel string,
+	channelCreation bool,
+	channelCategoryID string,
+	channelCascadeDelete bool,
+) *ServerConfiguration {
 	config := &ServerConfiguration{
-		GuildID:           guildId,
-		RoleAddRoleID:     addRole,
-		RoleRemoveRoleID:  removeRole,
-		RoleUpdateRoleID:  updateRole,
-		SelectorChannelID: selectorChannel,
+		GuildID:              guildId,
+		RoleAddRoleID:        addRole,
+		RoleRemoveRoleID:     removeRole,
+		RoleUpdateRoleID:     updateRole,
+		SelectorChannelID:    selectorChannel,
+		ChannelCreation:      channelCreation,
+		ChannelCategoryID:    channelCategoryID,
+		ChannelCascadeDelete: channelCascadeDelete,
 	}
 
 	db.DB.Create(config)
@@ -45,11 +63,22 @@ func (db *ReactRolesDatabase) ServerConfigurationCreate(guildId string, addRole 
 	return config
 }
 
-func (db *ReactRolesDatabase) ServerConfigurationUpdate(guildId string, addRole string, removeRole string, updateRole string, selectorChannel string) {
+func (db *ReactRolesDatabase) ServerConfigurationUpdate(guildId string,
+	addRole string,
+	removeRole string,
+	updateRole string,
+	selectorChannel string,
+	channelCreation bool,
+	channelCategoryID string,
+	channelCascadeDelete bool,
+) {
 	db.DB.Model(&ServerConfiguration{}).Where("guild_id = ?", guildId).Updates(ServerConfiguration{
-		RoleAddRoleID:     addRole,
-		RoleRemoveRoleID:  removeRole,
-		RoleUpdateRoleID:  updateRole,
-		SelectorChannelID: selectorChannel,
+		RoleAddRoleID:        addRole,
+		RoleRemoveRoleID:     removeRole,
+		RoleUpdateRoleID:     updateRole,
+		SelectorChannelID:    selectorChannel,
+		ChannelCreation:      channelCreation,
+		ChannelCategoryID:    channelCategoryID,
+		ChannelCascadeDelete: channelCascadeDelete,
 	})
 }


### PR DESCRIPTION
This PR adds:
* adds the ability to create channels linked to the roles, which are viewable by only role members
* server configuration to:
  * Enable channel creation `channel-creation`, which links the created channels to a role
  * Enable channel deletion `cascade-delete`, which deletes linked channels when a role is removed
* modifies the `/role remove` command to delete any linked channels if they exist, and if the server configuration has `cascade-delete = true`.

![image](https://github.com/Zaptross/reactroles/assets/26305909/886ab21a-44fe-48ad-b543-db74b8235de9)
![image](https://github.com/Zaptross/reactroles/assets/26305909/0c0ba84c-399e-4a4d-b757-e6b10af192a0)
